### PR TITLE
wip: transitive dependencies are handled incorrectly

### DIFF
--- a/app/Bad.tsx
+++ b/app/Bad.tsx
@@ -1,0 +1,5 @@
+import CinsComponent from "rsc-things/cins";
+
+export function Bad() {
+	return <CinsComponent />;
+}

--- a/app/Good.tsx
+++ b/app/Good.tsx
@@ -1,0 +1,5 @@
+import ServerComponent from "rsc-things/server";
+
+export function Good() {
+	return <ServerComponent filename="package.json" />;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,9 +1,9 @@
-import Counter from "./Counter";
 import fs from "node:fs";
-import { createServerContext, useContext, use } from "react";
 import { RouterContext } from "@hattip/router";
 import A from "../modules/router/A";
 import { SearchPage } from "./SearchPage";
+import { Good } from "./Good";
+import { Bad } from "./Bad";
 
 async function PackageJSON() {
 	const packageJson = await fs.promises.readFile("package.json", "utf8");
@@ -14,6 +14,8 @@ async function PackageJSON() {
 const routes = {
 	"/": SearchPage,
 	"/pkg": PackageJSON,
+	"/good": Good,
+	"/bad": Bad,
 } as Record<string, any>;
 
 export default function Root(context: RouterContext) {
@@ -26,8 +28,8 @@ export default function Root(context: RouterContext) {
 			</head>
 			<body>
 				<div>
-					<A href="/">Home</A>
-					<A href="/pkg">Package</A>
+					<A href="/">Home</A> | <A href="/pkg">Package</A> |{" "}
+					<A href="/good">Good</A> | <A href="/bad">Bad</A>
 				</div>
 				{(
 					<Component

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react": "18.3.0-next-85de6fde5-20230328",
     "react-dom": "18.3.0-next-85de6fde5-20230328",
     "react-resizable": "^3.0.5",
-    "react-server-dom-webpack": "18.3.0-next-85de6fde5-20230328"
+    "react-server-dom-webpack": "18.3.0-next-85de6fde5-20230328",
+    "rsc-things": "^0.0.1"
   },
   "devDependencies": {
     "@hattip/adapter-node": "^0.0.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ dependencies:
   react-server-dom-webpack:
     specifier: 18.3.0-next-85de6fde5-20230328
     version: 18.3.0-next-85de6fde5-20230328(react-dom@18.3.0-next-85de6fde5-20230328)(react@18.3.0-next-85de6fde5-20230328)(webpack@5.77.0)
+  rsc-things:
+    specifier: ^0.0.1
+    version: 0.0.1(react@18.3.0-next-85de6fde5-20230328)
 
 devDependencies:
   '@hattip/adapter-node':
@@ -1009,6 +1012,10 @@ packages:
     engines: {node: '>=6.0'}
     dev: false
 
+  /client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: false
+
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
@@ -1715,6 +1722,16 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rsc-things@0.0.1(react@18.3.0-next-85de6fde5-20230328):
+    resolution: {integrity: sha512-2HgZ56FY+ckQkVcFMErRpaG2XoLoNp4WED0Rch/51+7JmI/Ll4zm9FAx5rF96fnkfO2yDI1zcMLal0FX5PBcSw==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.0-next-85de6fde5-20230328
+      server-only: 0.0.1
+    dev: false
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -1743,6 +1760,10 @@ packages:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
+    dev: false
+
+  /server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
     dev: false
 
   /shebang-command@2.0.0:


### PR DESCRIPTION
This branch demonstrates the issue with transitive dependencies.

It adds two routes (`/good` and `/bad`). They import and render two server components from [a package I just published](https://github.com/cyco130/rsc-things) to test RSC related things.

The current toy plugin correctly resolves immediate dependencies in `node_modules` and transforms files within the project root. `/good` works because it imports a server component that don't call any further components.

But `/bad` imports a server component that calls a client component (both in `node_modules`). It fails with the error "This Hook is not supported in Server Components" because currently we're not resolving or transforming transitive dependencies.

This is caused by Vite simply importing the immediate dependency without further processing. Further resolution is handled by Node itself and it will not resolve or transform packages by itself. There are three ways to solve this:

1. Bundle the RSC module graph ahead of time, e.g. via ESBuild. This is not desirable because it's not how Vite works in dev. I wouldn't consider such a solution a proper *Vite* RSC implementation. But it I believe it's the best way forward for the build.
2. Keep the current scheme but for external dependencies use a require hook and an ESM loader.
3. Spawn a second Vite instance (maybe in a different process) and use it to resolve and transform RSC modules.

I will be investigating 2 and 3 (a combination may be required), posting back my findings here, and pushing my experiments to this branch.
